### PR TITLE
g++-5 is by default in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ git:
   depth: 1
 
 addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
+  apt:    
     packages:
-      - gcc-5
-      - g++-5
       - libtommath0


### PR DESCRIPTION
g++-5 is by default in travis config 
no need for extra toochains