### PR TITLE
Implementation of isValid property

### DIFF
--- a/packages/node-firebird-driver-native/src/lib/blob.ts
+++ b/packages/node-firebird-driver-native/src/lib/blob.ts
@@ -88,7 +88,7 @@ export class BlobStreamImpl extends AbstractBlobStream {
 		});
 	}
 
-	isValid(): boolean {
-		return !!this.blobHandle && this.attachment.isValid();
+	get isValid(): boolean {
+		return !!this.blobHandle && this.attachment.isValid;
 	}
 }

--- a/packages/node-firebird-driver-native/src/lib/blob.ts
+++ b/packages/node-firebird-driver-native/src/lib/blob.ts
@@ -87,4 +87,8 @@ export class BlobStreamImpl extends AbstractBlobStream {
 			}
 		});
 	}
+
+	isValid() {
+		return !!this.blobHandle && this.attachment.isValid();
+	}
 }

--- a/packages/node-firebird-driver-native/src/lib/blob.ts
+++ b/packages/node-firebird-driver-native/src/lib/blob.ts
@@ -88,7 +88,7 @@ export class BlobStreamImpl extends AbstractBlobStream {
 		});
 	}
 
-	isValid() {
+	isValid(): boolean {
 		return !!this.blobHandle && this.attachment.isValid();
 	}
 }

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -194,12 +194,12 @@ export abstract class AbstractAttachment implements Attachment {
 		return statement;
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.client;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('Attachment is already disconnected.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -194,6 +194,10 @@ export abstract class AbstractAttachment implements Attachment {
 		return statement;
 	}
 
+	isValid() {
+		return !!this.client;
+	}
+
 	private check() {
 		if (!this.client)
 			throw new Error('Attachment is already disconnected.');

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -194,7 +194,7 @@ export abstract class AbstractAttachment implements Attachment {
 		return statement;
 	}
 
-	isValid() {
+	isValid(): boolean {
 		return !!this.client;
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -199,7 +199,7 @@ export abstract class AbstractAttachment implements Attachment {
 	}
 
 	private check() {
-		if (!this.client)
+		if (!this.isValid())
 			throw new Error('Attachment is already disconnected.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/client.ts
+++ b/packages/node-firebird-driver/src/lib/impl/client.ts
@@ -77,7 +77,7 @@ export abstract class AbstractClient implements Client {
 	}
 
 	private check() {
-		if (!this.connected)
+		if (!this.isValid())
 			throw new Error('Client is already disposed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/client.ts
+++ b/packages/node-firebird-driver/src/lib/impl/client.ts
@@ -72,12 +72,12 @@ export abstract class AbstractClient implements Client {
 		return attachment;
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.connected;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('Client is already disposed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/client.ts
+++ b/packages/node-firebird-driver/src/lib/impl/client.ts
@@ -72,6 +72,10 @@ export abstract class AbstractClient implements Client {
 		return attachment;
 	}
 
+	isValid() {
+		return !!this.connected;
+	}
+
 	private check() {
 		if (!this.connected)
 			throw new Error('Client is already disposed.');

--- a/packages/node-firebird-driver/src/lib/impl/client.ts
+++ b/packages/node-firebird-driver/src/lib/impl/client.ts
@@ -72,7 +72,7 @@ export abstract class AbstractClient implements Client {
 		return attachment;
 	}
 
-	isValid() {
+	isValid(): boolean {
 		return !!this.connected;
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/events.ts
+++ b/packages/node-firebird-driver/src/lib/impl/events.ts
@@ -18,12 +18,12 @@ export abstract class AbstractEvents implements Events {
 		this.attachment = undefined;
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.attachment;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('Events are already cancelled.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/events.ts
+++ b/packages/node-firebird-driver/src/lib/impl/events.ts
@@ -18,7 +18,7 @@ export abstract class AbstractEvents implements Events {
 		this.attachment = undefined;
 	}
 
-	isValid() {
+	isValid(): boolean {
 		return !!this.attachment;
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/events.ts
+++ b/packages/node-firebird-driver/src/lib/impl/events.ts
@@ -18,8 +18,12 @@ export abstract class AbstractEvents implements Events {
 		this.attachment = undefined;
 	}
 
+	isValid() {
+		return !!this.attachment;
+	}
+
 	private check() {
-		if (!this.attachment)
+		if (!this.isValid())
 			throw new Error('Events are already cancelled.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/resultset.ts
+++ b/packages/node-firebird-driver/src/lib/impl/resultset.ts
@@ -84,7 +84,7 @@ export abstract class AbstractResultSet implements ResultSet {
 	}
 
 	private check() {
-		if (!this.statement)
+		if (!this.isValid())
 			throw new Error('ResultSet is already closed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/resultset.ts
+++ b/packages/node-firebird-driver/src/lib/impl/resultset.ts
@@ -79,6 +79,10 @@ export abstract class AbstractResultSet implements ResultSet {
 		});
 	}
 
+	isValid(): boolean {
+		return !!this.statement;
+	}
+
 	private check() {
 		if (!this.statement)
 			throw new Error('ResultSet is already closed.');

--- a/packages/node-firebird-driver/src/lib/impl/resultset.ts
+++ b/packages/node-firebird-driver/src/lib/impl/resultset.ts
@@ -79,12 +79,12 @@ export abstract class AbstractResultSet implements ResultSet {
 		});
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.statement;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('ResultSet is already closed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/statement.ts
+++ b/packages/node-firebird-driver/src/lib/impl/statement.ts
@@ -104,6 +104,10 @@ export abstract class AbstractStatement implements Statement {
 		return resultSet;
 	}
 
+	isValid() {
+		return !!this.attachment;
+	}
+
 	private check() {
 		if (!this.attachment)
 			throw new Error('Statement is already disposed.');

--- a/packages/node-firebird-driver/src/lib/impl/statement.ts
+++ b/packages/node-firebird-driver/src/lib/impl/statement.ts
@@ -104,12 +104,12 @@ export abstract class AbstractStatement implements Statement {
 		return resultSet;
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.attachment;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('Statement is already disposed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/statement.ts
+++ b/packages/node-firebird-driver/src/lib/impl/statement.ts
@@ -104,12 +104,12 @@ export abstract class AbstractStatement implements Statement {
 		return resultSet;
 	}
 
-	isValid() {
+	isValid(): boolean {
 		return !!this.attachment;
 	}
 
 	private check() {
-		if (!this.attachment)
+		if (!this.isValid())
 			throw new Error('Statement is already disposed.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/transaction.ts
+++ b/packages/node-firebird-driver/src/lib/impl/transaction.ts
@@ -42,9 +42,9 @@ export abstract class AbstractTransaction implements Transaction {
 		return await this.internalRollbackRetaining();
 	}
 
-  inTransaction(): boolean {
-    return !!this.attachment;
-  }
+	isValid(): boolean {
+		return !!this.attachment;
+	}
 
 	private check() {
 		if (!this.attachment)

--- a/packages/node-firebird-driver/src/lib/impl/transaction.ts
+++ b/packages/node-firebird-driver/src/lib/impl/transaction.ts
@@ -42,6 +42,10 @@ export abstract class AbstractTransaction implements Transaction {
 		return await this.internalRollbackRetaining();
 	}
 
+  inTransaction(): boolean {
+    return !!this.attachment;
+  }
+
 	private check() {
 		if (!this.attachment)
 			throw new Error('Transaction is already committed or rolled back.');

--- a/packages/node-firebird-driver/src/lib/impl/transaction.ts
+++ b/packages/node-firebird-driver/src/lib/impl/transaction.ts
@@ -47,7 +47,7 @@ export abstract class AbstractTransaction implements Transaction {
 	}
 
 	private check() {
-		if (!this.attachment)
+		if (!this.isValid())
 			throw new Error('Transaction is already committed or rolled back.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/impl/transaction.ts
+++ b/packages/node-firebird-driver/src/lib/impl/transaction.ts
@@ -42,12 +42,12 @@ export abstract class AbstractTransaction implements Transaction {
 		return await this.internalRollbackRetaining();
 	}
 
-	isValid(): boolean {
+	get isValid(): boolean {
 		return !!this.attachment;
 	}
 
 	private check() {
-		if (!this.isValid())
+		if (!this.isValid)
 			throw new Error('Transaction is already committed or rolled back.');
 	}
 

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -1,5 +1,9 @@
+interface WithIsValidFlag {
+  isValid(): boolean;
+}
+
 /** Client interface. */
-export interface Client {
+export interface Client extends WithIsValidFlag {
 	/** Disposes this client's resources. */
 	dispose(): Promise<void>;
 
@@ -88,7 +92,7 @@ export interface FetchOptions {
 }
 
 /** Attachment interface. */
-export interface Attachment {
+export interface Attachment extends WithIsValidFlag {
 	/** Disconnects this attachment. */
 	disconnect(): Promise<void>;
 
@@ -160,7 +164,7 @@ export interface Attachment {
 }
 
 /** Transaction interface. */
-export interface Transaction {
+export interface Transaction extends WithIsValidFlag {
 	/** Commits and release this transaction object. */
 	commit(): Promise<void>;
 
@@ -172,13 +176,10 @@ export interface Transaction {
 
 	/** Rollbacks and maintains this transaction object for subsequent work. */
 	rollbackRetaining(): Promise<void>;
-
-  /** Returns true if current transaction active. The name follows name of the Delphi TIBTransaction class */
-  inTransaction(): boolean;
 }
 
 /** Statement interface. */
-export interface Statement {
+export interface Statement extends WithIsValidFlag {
 	/** Disposes this statement's resources. */
 	dispose(): Promise<void>;
 
@@ -224,7 +225,7 @@ export interface Statement {
 }
 
 /** ResultSet interface. */
-export interface ResultSet {
+export interface ResultSet extends WithIsValidFlag {
 	/** Closes this result set. */
 	close(): Promise<void>;
 
@@ -270,7 +271,7 @@ export class Blob {
 }
 
 /** BlobStream class. */
-export abstract class BlobStream {
+export abstract class BlobStream implements WithIsValidFlag {
 	/** Gets the blob's. */
 	readonly blob: Blob;
 
@@ -295,6 +296,8 @@ export abstract class BlobStream {
 
 	/** Writes data to the blob. */
 	abstract write(buffer: Buffer): Promise<void>;
+
+	abstract isValid(): boolean;
 }
 
 /** TIME WITH TIME ZONE and TIMESTAMP WITH TIME ZONE to be sent as parameter */

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -172,6 +172,9 @@ export interface Transaction {
 
 	/** Rollbacks and maintains this transaction object for subsequent work. */
 	rollbackRetaining(): Promise<void>;
+
+  /** Returns true if current transaction active. The name follows name of the Delphi TIBTransaction class */
+  inTransaction(): boolean;
 }
 
 /** Statement interface. */

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -10,7 +10,7 @@ export interface Client {
 	createDatabase(uri: string, options?: CreateDatabaseOptions): Promise<Attachment>;
 
 	/** True if the client has not been disposed */
-	isValid(): boolean;
+	readonly isValid: boolean;
 
 	/** Default connect options. */
 	defaultConnectOptions?: ConnectOptions;
@@ -147,7 +147,7 @@ export interface Attachment {
 	queueEvents(names: string[], callBack: (counters: [string, number][]) => Promise<void>): Promise<Events>;
 
 	/** True if the attachment connected */
-	isValid(): boolean;
+	readonly isValid: boolean;
 
 	/** Default transaction options. */
 	defaultTransactionOptions?: TransactionOptions;
@@ -180,7 +180,7 @@ export interface Transaction {
 	rollbackRetaining(): Promise<void>;
 
 	/** True if the transaction active */
-	isValid(): boolean;
+	readonly isValid: boolean;
 }
 
 /** Statement interface. */
@@ -214,7 +214,7 @@ export interface Statement {
 	getExecPathText(): Promise<string | undefined>;
 
 	/** True if the statement has not been disposed */
-	isValid(): boolean;
+	readonly isValid: boolean;
 
 	/** Gets the query's result columns labels. Returns empty array for queries without result. */
 	readonly columnLabels: Promise<string[]>;
@@ -257,7 +257,7 @@ export interface ResultSet {
 	fetchAsObject<T extends object>(options?: FetchOptions): Promise<T[]>;
 
 	/** True if the ResultSet open */
-	isValid(): boolean;
+	readonly isValid: boolean;
 
 	/** Default result set's fetch options. */
 	defaultFetchOptions?: FetchOptions;
@@ -267,7 +267,7 @@ export interface Events {
 	cancel(): Promise<void>;
 
 	/** True if the events's attachment is valid */
-	isValid(): boolean;
+	readonly isValid: boolean;
 }
 
 /** Blob class. */
@@ -284,8 +284,8 @@ export class Blob {
 	}
 
 	/** True if the blob's attachment is valid */
-	isValid(): boolean {
-		return !!this.attachment.isValid();
+	get isValid(): boolean {
+		return !!this.attachment.isValid;
 	}
 }
 
@@ -317,7 +317,7 @@ export abstract class BlobStream {
 	abstract write(buffer: Buffer): Promise<void>;
 
 	/** True if the blob stream is open */
-	abstract isValid(): boolean;
+	abstract get isValid(): boolean;
 }
 
 /** TIME WITH TIME ZONE and TIMESTAMP WITH TIME ZONE to be sent as parameter */

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -1,9 +1,5 @@
-interface WithIsValidFlag {
-  isValid(): boolean;
-}
-
 /** Client interface. */
-export interface Client extends WithIsValidFlag {
+export interface Client {
 	/** Disposes this client's resources. */
 	dispose(): Promise<void>;
 
@@ -12,6 +8,9 @@ export interface Client extends WithIsValidFlag {
 
 	/** Creates a database. */
 	createDatabase(uri: string, options?: CreateDatabaseOptions): Promise<Attachment>;
+
+	/** True if the client has not been disposed */
+	isValid(): boolean;
 
 	/** Default connect options. */
 	defaultConnectOptions?: ConnectOptions;
@@ -92,7 +91,7 @@ export interface FetchOptions {
 }
 
 /** Attachment interface. */
-export interface Attachment extends WithIsValidFlag {
+export interface Attachment {
 	/** Disconnects this attachment. */
 	disconnect(): Promise<void>;
 
@@ -147,6 +146,9 @@ export interface Attachment extends WithIsValidFlag {
 
 	queueEvents(names: string[], callBack: (counters: [string, number][]) => Promise<void>): Promise<Events>;
 
+	/** True if the attachment connected */
+	isValid(): boolean;
+
 	/** Default transaction options. */
 	defaultTransactionOptions?: TransactionOptions;
 
@@ -164,7 +166,7 @@ export interface Attachment extends WithIsValidFlag {
 }
 
 /** Transaction interface. */
-export interface Transaction extends WithIsValidFlag {
+export interface Transaction {
 	/** Commits and release this transaction object. */
 	commit(): Promise<void>;
 
@@ -176,10 +178,13 @@ export interface Transaction extends WithIsValidFlag {
 
 	/** Rollbacks and maintains this transaction object for subsequent work. */
 	rollbackRetaining(): Promise<void>;
+
+	/** True if the transaction active */
+	isValid(): boolean;
 }
 
 /** Statement interface. */
-export interface Statement extends WithIsValidFlag {
+export interface Statement {
 	/** Disposes this statement's resources. */
 	dispose(): Promise<void>;
 
@@ -208,6 +213,9 @@ export interface Statement extends WithIsValidFlag {
 
 	getExecPathText(): Promise<string | undefined>;
 
+	/** True if the statement has not been disposed */
+	isValid(): boolean;
+
 	/** Gets the query's result columns labels. Returns empty array for queries without result. */
 	readonly columnLabels: Promise<string[]>;
 
@@ -225,7 +233,7 @@ export interface Statement extends WithIsValidFlag {
 }
 
 /** ResultSet interface. */
-export interface ResultSet extends WithIsValidFlag {
+export interface ResultSet {
 	/** Closes this result set. */
 	close(): Promise<void>;
 
@@ -248,12 +256,18 @@ export interface ResultSet extends WithIsValidFlag {
 	 */
 	fetchAsObject<T extends object>(options?: FetchOptions): Promise<T[]>;
 
+	/** True if the ResultSet open */
+	isValid(): boolean;
+
 	/** Default result set's fetch options. */
 	defaultFetchOptions?: FetchOptions;
 }
 
 export interface Events {
 	cancel(): Promise<void>;
+
+	/** True if the events's attachment is valid */
+	isValid(): boolean;
 }
 
 /** Blob class. */
@@ -268,10 +282,15 @@ export class Blob {
 		this.attachment = attachment;
 		this.id.set(id);
 	}
+
+	/** True if the blob's attachment is valid */
+	isValid(): boolean {
+		return !!this.attachment.isValid();
+	}
 }
 
 /** BlobStream class. */
-export abstract class BlobStream implements WithIsValidFlag {
+export abstract class BlobStream {
 	/** Gets the blob's. */
 	readonly blob: Blob;
 
@@ -297,6 +316,7 @@ export abstract class BlobStream implements WithIsValidFlag {
 	/** Writes data to the blob. */
 	abstract write(buffer: Buffer): Promise<void>;
 
+	/** True if the blob stream is open */
 	abstract isValid(): boolean;
 }
 

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -1,4 +1,5 @@
 import {
+	Attachment,
 	Blob,
 	Client,
 	TransactionIsolation,
@@ -45,6 +46,14 @@ export function runCommonTests(client: Client) {
 			`${d.getUTCHours()}:${d.getUTCMinutes()}:${d.getUTCSeconds()}.${d.getUTCMilliseconds()} ${zd.timeZone}'`;
 	}
 
+	async function isFB4OrGreater(attachment: Attachment) {
+		const transaction = await attachment.startTransaction();
+		const resultSet = await attachment.executeQuery(transaction, 'select mon$ods_major from mon$database');
+		const output = await resultSet.fetchAsObject<{ MON$ODS_MAJOR: number }>();
+		await resultSet.close();
+		await transaction.commit();
+		return output[0].MON$ODS_MAJOR >= 13;
+	}
 
 	describe('node-firebird-driver', () => {
 		const testConfig = {
@@ -74,6 +83,8 @@ export function runCommonTests(client: Client) {
 
 
 		beforeAll(() => {
+			expect(client.isValid()).toBeTruthy();
+
 			if (isLocal() && !testConfig.tmpDir) {
 				testConfig.tmpDir = tmp.mkdirSync().path.toString();
 
@@ -99,6 +110,8 @@ export function runCommonTests(client: Client) {
 		afterAll(async () => {
 			await client.dispose();
 
+			expect(client.isValid()).toBeFalsy();
+
 			if (isLocal())
 				fs.rmdirSync(testConfig.tmpDir!);
 		});
@@ -114,8 +127,14 @@ export function runCommonTests(client: Client) {
 				const attachment1 = await client.createDatabase(filename);
 				const attachment2 = await client.connect(filename);
 
+				expect(attachment1.isValid()).toBeTruthy();
+				expect(attachment2.isValid()).toBeTruthy();
+
 				await attachment2.disconnect();
 				await attachment1.dropDatabase();
+
+				expect(attachment1.isValid()).toBeFalsy();
+				expect(attachment2.isValid()).toBeFalsy();
 			});
 		});
 
@@ -126,16 +145,22 @@ export function runCommonTests(client: Client) {
 				const isolationQuery = 'select rdb$get_context(\'SYSTEM\', \'ISOLATION_LEVEL\') from rdb$database';
 
 				const transaction1 = await attachment.startTransaction();
+				expect(transaction1.isValid()).toBeTruthy()
 				expect((await attachment.executeReturning(transaction1, isolationQuery))[0]).toBe('SNAPSHOT');
 				await transaction1.commit();
+				expect(transaction1.isValid()).toBeFalsy()
 
 				const transaction2 = await attachment.startTransaction({ isolation: TransactionIsolation.READ_COMMITTED });
+				expect(transaction2.isValid()).toBeTruthy()
 				expect((await attachment.executeReturning(transaction2, isolationQuery))[0]).toBe('READ COMMITTED');
 				await transaction2.commit();
+				expect(transaction2.isValid()).toBeFalsy()
 
 				const transaction3 = await attachment.startTransaction({ isolation: TransactionIsolation.CONSISTENCY });
+				expect(transaction3.isValid()).toBeTruthy()
 				expect((await attachment.executeReturning(transaction3, isolationQuery))[0]).toBe('CONSISTENCY');
 				await transaction3.commit();
+				expect(transaction3.isValid()).toBeFalsy()
 
 				await attachment.dropDatabase();
 			});
@@ -145,7 +170,9 @@ export function runCommonTests(client: Client) {
 				const transaction = await attachment.startTransaction();
 
 				const statement = await attachment.prepare(transaction, 'create table t1 (n1 integer)');
+				expect(statement.isValid()).toBeTruthy();
 				await statement.dispose();
+				expect(statement.isValid()).toBeFalsy();
 
 				let error: Error | undefined;
 				try {
@@ -189,7 +216,9 @@ export function runCommonTests(client: Client) {
 				await transaction.commitRetaining();
 
 				const resultSet = await attachment.executeQuery(transaction, 'select n1 from t1');
+				expect(resultSet.isValid()).toBeTruthy();
 				await resultSet.close();
+				expect(resultSet.isValid()).toBeFalsy();
 
 				await transaction.commit();
 				await attachment.dropDatabase();
@@ -275,20 +304,22 @@ export function runCommonTests(client: Client) {
 						await attachment.execute(transaction, `
 							execute block as
 							begin
-							    post_event 'EVENT1';
-							    post_event 'EVENT1';
-							    post_event 'EVENT2';
-							    post_event 'EVENT3';
+									post_event 'EVENT1';
+									post_event 'EVENT1';
+									post_event 'EVENT2';
+									post_event 'EVENT3';
 							end
 						`);
 
 						// Commit retaining to test internal event rescheduling
 						// after each handler dispatch.
 						await transaction.commitRetaining();
+						expect(transaction.isValid()).toBeTruthy();
 					}
 				}
 				finally {
 					await transaction.commit();
+					expect(transaction.isValid()).toBeFalsy();
 				}
 
 				await Promise.all(eventsObj.map(ev => ev.promise));
@@ -355,7 +386,9 @@ export function runCommonTests(client: Client) {
 				await statement2.execute(transaction, [null]);
 				await statement2.execute(transaction, [10]);
 				await statement2.execute(transaction, [100]);
+				expect(statement2.isValid()).toBeTruthy();
 				await statement2.dispose();
+				expect(statement2.isValid()).toBeFalsy();
 
 				const rs = await attachment.executeQuery(transaction,
 					`select sum(n1) || ', ' || count(n1) || ', ' || count(*) ret from t1`);
@@ -439,9 +472,11 @@ export function runCommonTests(client: Client) {
 				expect(statement2.hasResultSet).toBe(false);
 				await statement2.dispose();
 
-				const statement3 = await attachment.prepare(transaction, 'insert into t1 values (1) returning *');
-				expect(statement3.hasResultSet).toBe(false);
-				await statement3.dispose();
+				if (await isFB4OrGreater(attachment)) {
+					const statement3 = await attachment.prepare(transaction, 'insert into t1 values (1) returning *');
+					expect(statement3.hasResultSet).toBe(false);
+					await statement3.dispose();
+				}
 
 				const statement4 = await attachment.prepare(transaction, 'execute block as begin end');
 				expect(statement4.hasResultSet).toBe(false);
@@ -467,6 +502,11 @@ export function runCommonTests(client: Client) {
 		describe('ResultSet', () => {
 			test('#fetch()', async () => {
 				const attachment = await client.createDatabase(getTempFile('ResultSet-fetch.fdb'));
+
+				if (!(await isFB4OrGreater(attachment))) {
+					return;
+				}
+
 				let transaction = await attachment.startTransaction();
 
 				const blobBuffer = Buffer.alloc(11, '12345678á9');
@@ -538,8 +578,11 @@ export function runCommonTests(client: Client) {
 					transaction = await attachment.startTransaction();
 
 					const blob = await attachment.createBlob(transaction);
+					expect(blob.isValid()).toBeTruthy();
 					await blob.write(blobBuffer);
+					expect(blob.isValid()).toBeTruthy();
 					await blob.close();
+					expect(blob.isValid()).toBeFalsy();
 
 					parameters = [
 						-1,

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -293,14 +293,14 @@ export function runCommonTests(client: Client) {
 					// eventHandler may have a chance to cancel the events.
 					for (let i = 0; i < 20; ++i) {
 						await attachment.execute(transaction, `
-              execute block as
-              begin
-                post_event 'EVENT1';
-                post_event 'EVENT1';
-                post_event 'EVENT2';
-                post_event 'EVENT3';
-              end
-              `);
+							execute block as
+							begin
+							    post_event 'EVENT1';
+							    post_event 'EVENT1';
+							    post_event 'EVENT2';
+							    post_event 'EVENT3';
+							end
+						`);
 
 						// Commit retaining to test internal event rescheduling
 						// after each handler dispatch.

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -73,7 +73,7 @@ export function runCommonTests(client: Client) {
 
 
 		beforeAll(() => {
-			expect(client.isValid()).toBeTruthy();
+			expect(client.isValid).toBeTruthy();
 
 			if (isLocal() && !testConfig.tmpDir) {
 				testConfig.tmpDir = tmp.mkdirSync().path.toString();
@@ -100,7 +100,7 @@ export function runCommonTests(client: Client) {
 		afterAll(async () => {
 			await client.dispose();
 
-			expect(client.isValid()).toBeFalsy();
+			expect(client.isValid).toBeFalsy();
 
 			if (isLocal())
 				fs.rmdirSync(testConfig.tmpDir!);
@@ -117,14 +117,14 @@ export function runCommonTests(client: Client) {
 				const attachment1 = await client.createDatabase(filename);
 				const attachment2 = await client.connect(filename);
 
-				expect(attachment1.isValid()).toBeTruthy();
-				expect(attachment2.isValid()).toBeTruthy();
+				expect(attachment1.isValid).toBeTruthy();
+				expect(attachment2.isValid).toBeTruthy();
 
 				await attachment2.disconnect();
 				await attachment1.dropDatabase();
 
-				expect(attachment1.isValid()).toBeFalsy();
-				expect(attachment2.isValid()).toBeFalsy();
+				expect(attachment1.isValid).toBeFalsy();
+				expect(attachment2.isValid).toBeFalsy();
 			});
 		});
 
@@ -135,22 +135,22 @@ export function runCommonTests(client: Client) {
 				const isolationQuery = 'select rdb$get_context(\'SYSTEM\', \'ISOLATION_LEVEL\') from rdb$database';
 
 				const transaction1 = await attachment.startTransaction();
-				expect(transaction1.isValid()).toBeTruthy()
+				expect(transaction1.isValid).toBeTruthy()
 				expect((await attachment.executeReturning(transaction1, isolationQuery))[0]).toBe('SNAPSHOT');
 				await transaction1.commit();
-				expect(transaction1.isValid()).toBeFalsy()
+				expect(transaction1.isValid).toBeFalsy()
 
 				const transaction2 = await attachment.startTransaction({ isolation: TransactionIsolation.READ_COMMITTED });
-				expect(transaction2.isValid()).toBeTruthy()
+				expect(transaction2.isValid).toBeTruthy()
 				expect((await attachment.executeReturning(transaction2, isolationQuery))[0]).toBe('READ COMMITTED');
 				await transaction2.commit();
-				expect(transaction2.isValid()).toBeFalsy()
+				expect(transaction2.isValid).toBeFalsy()
 
 				const transaction3 = await attachment.startTransaction({ isolation: TransactionIsolation.CONSISTENCY });
-				expect(transaction3.isValid()).toBeTruthy()
+				expect(transaction3.isValid).toBeTruthy()
 				expect((await attachment.executeReturning(transaction3, isolationQuery))[0]).toBe('CONSISTENCY');
 				await transaction3.commit();
-				expect(transaction3.isValid()).toBeFalsy()
+				expect(transaction3.isValid).toBeFalsy()
 
 				await attachment.dropDatabase();
 			});
@@ -160,9 +160,9 @@ export function runCommonTests(client: Client) {
 				const transaction = await attachment.startTransaction();
 
 				const statement = await attachment.prepare(transaction, 'create table t1 (n1 integer)');
-				expect(statement.isValid()).toBeTruthy();
+				expect(statement.isValid).toBeTruthy();
 				await statement.dispose();
-				expect(statement.isValid()).toBeFalsy();
+				expect(statement.isValid).toBeFalsy();
 
 				let error: Error | undefined;
 				try {
@@ -206,9 +206,9 @@ export function runCommonTests(client: Client) {
 				await transaction.commitRetaining();
 
 				const resultSet = await attachment.executeQuery(transaction, 'select n1 from t1');
-				expect(resultSet.isValid()).toBeTruthy();
+				expect(resultSet.isValid).toBeTruthy();
 				await resultSet.close();
-				expect(resultSet.isValid()).toBeFalsy();
+				expect(resultSet.isValid).toBeFalsy();
 
 				await transaction.commit();
 				await attachment.dropDatabase();
@@ -279,7 +279,7 @@ export function runCommonTests(client: Client) {
 					if (Array.from(eventsMap.values()).every(obj => obj.count >= obj.expected)) {
 						if (events) {
 							await events.cancel();
-							expect(events.isValid()).toBeFalsy();
+							expect(events.isValid).toBeFalsy();
 							events = null!;
 						}
 					}
@@ -305,12 +305,12 @@ export function runCommonTests(client: Client) {
 						// Commit retaining to test internal event rescheduling
 						// after each handler dispatch.
 						await transaction.commitRetaining();
-						expect(transaction.isValid()).toBeTruthy();
+						expect(transaction.isValid).toBeTruthy();
 					}
 				}
 				finally {
 					await transaction.commit();
-					expect(transaction.isValid()).toBeFalsy();
+					expect(transaction.isValid).toBeFalsy();
 				}
 
 				await Promise.all(eventsObj.map(ev => ev.promise));
@@ -377,9 +377,9 @@ export function runCommonTests(client: Client) {
 				await statement2.execute(transaction, [null]);
 				await statement2.execute(transaction, [10]);
 				await statement2.execute(transaction, [100]);
-				expect(statement2.isValid()).toBeTruthy();
+				expect(statement2.isValid).toBeTruthy();
 				await statement2.dispose();
-				expect(statement2.isValid()).toBeFalsy();
+				expect(statement2.isValid).toBeFalsy();
 
 				const rs = await attachment.executeQuery(transaction,
 					`select sum(n1) || ', ' || count(n1) || ', ' || count(*) ret from t1`);
@@ -563,11 +563,11 @@ export function runCommonTests(client: Client) {
 					transaction = await attachment.startTransaction();
 
 					const blob = await attachment.createBlob(transaction);
-					expect(blob.isValid()).toBeTruthy();
+					expect(blob.isValid).toBeTruthy();
 					await blob.write(blobBuffer);
-					expect(blob.isValid()).toBeTruthy();
+					expect(blob.isValid).toBeTruthy();
 					await blob.close();
-					expect(blob.isValid()).toBeFalsy();
+					expect(blob.isValid).toBeFalsy();
 
 					parameters = [
 						-1,
@@ -695,7 +695,7 @@ export function runCommonTests(client: Client) {
 
 					for (const i = n + 2; n < i; ++n) {
 						const blob = columns[n] as Blob;
-						expect(blob.isValid()).toBeTruthy();
+						expect(blob.isValid).toBeTruthy();
 						const blobStream = await attachment.openBlob(transaction, blob);
 						const buffer = Buffer.alloc(await blobStream.length);
 						expect(await blobStream.read(buffer)).toBe(buffer.length);

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -1,5 +1,4 @@
 import {
-	Attachment,
 	Blob,
 	Client,
 	TransactionIsolation,
@@ -44,15 +43,6 @@ export function runCommonTests(client: Client) {
 
 		return `timestamp '${(d.getUTCFullYear() + '').padStart(4, '0')}-${d.getUTCMonth() + 1}-${d.getUTCDate()} ` +
 			`${d.getUTCHours()}:${d.getUTCMinutes()}:${d.getUTCSeconds()}.${d.getUTCMilliseconds()} ${zd.timeZone}'`;
-	}
-
-	async function isFB4OrGreater(attachment: Attachment) {
-		const transaction = await attachment.startTransaction();
-		const resultSet = await attachment.executeQuery(transaction, 'select mon$ods_major from mon$database');
-		const output = await resultSet.fetchAsObject<{ MON$ODS_MAJOR: number }>();
-		await resultSet.close();
-		await transaction.commit();
-		return output[0].MON$ODS_MAJOR >= 13;
 	}
 
 	describe('node-firebird-driver', () => {
@@ -473,11 +463,9 @@ export function runCommonTests(client: Client) {
 				expect(statement2.hasResultSet).toBe(false);
 				await statement2.dispose();
 
-				if (await isFB4OrGreater(attachment)) {
-					const statement3 = await attachment.prepare(transaction, 'insert into t1 values (1) returning *');
-					expect(statement3.hasResultSet).toBe(false);
-					await statement3.dispose();
-				}
+				const statement3 = await attachment.prepare(transaction, 'insert into t1 values (1) returning *');
+				expect(statement3.hasResultSet).toBe(false);
+				await statement3.dispose();
 
 				const statement4 = await attachment.prepare(transaction, 'execute block as begin end');
 				expect(statement4.hasResultSet).toBe(false);
@@ -503,10 +491,6 @@ export function runCommonTests(client: Client) {
 		describe('ResultSet', () => {
 			test('#fetch()', async () => {
 				const attachment = await client.createDatabase(getTempFile('ResultSet-fetch.fdb'));
-
-				if (!(await isFB4OrGreater(attachment))) {
-					return;
-				}
 
 				let transaction = await attachment.startTransaction();
 

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -289,6 +289,7 @@ export function runCommonTests(client: Client) {
 					if (Array.from(eventsMap.values()).every(obj => obj.count >= obj.expected)) {
 						if (events) {
 							await events.cancel();
+							expect(events.isValid()).toBeFalsy();
 							events = null!;
 						}
 					}
@@ -302,14 +303,14 @@ export function runCommonTests(client: Client) {
 					// eventHandler may have a chance to cancel the events.
 					for (let i = 0; i < 20; ++i) {
 						await attachment.execute(transaction, `
-							execute block as
-							begin
-									post_event 'EVENT1';
-									post_event 'EVENT1';
-									post_event 'EVENT2';
-									post_event 'EVENT3';
-							end
-						`);
+              execute block as
+              begin
+                post_event 'EVENT1';
+                post_event 'EVENT1';
+                post_event 'EVENT2';
+                post_event 'EVENT3';
+              end
+              `);
 
 						// Commit retaining to test internal event rescheduling
 						// after each handler dispatch.
@@ -710,6 +711,7 @@ export function runCommonTests(client: Client) {
 
 					for (const i = n + 2; n < i; ++n) {
 						const blob = columns[n] as Blob;
+						expect(blob.isValid()).toBeTruthy();
 						const blobStream = await attachment.openBlob(transaction, blob);
 						const buffer = Buffer.alloc(await blobStream.length);
 						expect(await blobStream.read(buffer)).toBe(buffer.length);


### PR DESCRIPTION
IsValid() function implemented for objects Client, Attachment, Transaction, Statement, ResultSet, BlobStream. So, we can test the object's validity after commit(), rollback(), dispose(), close() etc. methods have been invoked.

The newly added method is covered through the tests. In two places the tests have been adapted to be able to run on FB3.

Example of usage:
```ts
const transaction = await attachment.startTransaction();
try {
  ...
  // some code where the transaction could be committed or rolled back
  // but there are also conditions for the transaction to stay alive
  // until the code ends
  ...
} finally {
  if (transaction.isValid()) await transaction.commit();
}
```