### PR TITLE
feat: add configurable connection charset (lc_ctype)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lerna-debug.log
 yarn-error.log
 tsconfig.tsbuildinfo
 .env
+*.tgz

--- a/packages/node-firebird-driver-native/src/lib/attachment.ts
+++ b/packages/node-firebird-driver-native/src/lib/attachment.ts
@@ -3,7 +3,7 @@ import { ClientImpl } from './client';
 import { StatementImpl } from './statement';
 import { TransactionImpl } from './transaction';
 import { EventsImpl } from './events';
-import { createDpb, mapCharsetToEncoding } from './fb-util';
+import { createDpb, createCharsetCodec, CharsetCodec } from './fb-util';
 
 import {
   Blob,
@@ -25,9 +25,11 @@ export class AttachmentImpl extends AbstractAttachment {
 
   attachmentHandle?: fb.Attachment;
 
+  charsetCodec: CharsetCodec;
+
   static async connect(client: ClientImpl, uri: string, options?: ConnectOptions): Promise<AttachmentImpl> {
     const attachment = new AttachmentImpl(client);
-    attachment.encoding = mapCharsetToEncoding(options?.charset);
+    attachment.charsetCodec = createCharsetCodec(options?.charset);
 
     return await client.statusAction(async (status) => {
       const dpb = createDpb(options);
@@ -42,6 +44,7 @@ export class AttachmentImpl extends AbstractAttachment {
     options?: CreateDatabaseOptions,
   ): Promise<AttachmentImpl> {
     const attachment = new AttachmentImpl(client);
+    attachment.charsetCodec = createCharsetCodec(options?.charset);
 
     return await client.statusAction(async (status) => {
       const dpb = createDpb(options);

--- a/packages/node-firebird-driver-native/src/lib/attachment.ts
+++ b/packages/node-firebird-driver-native/src/lib/attachment.ts
@@ -3,7 +3,7 @@ import { ClientImpl } from './client';
 import { StatementImpl } from './statement';
 import { TransactionImpl } from './transaction';
 import { EventsImpl } from './events';
-import { createDpb } from './fb-util';
+import { createDpb, mapCharsetToEncoding } from './fb-util';
 
 import {
   Blob,
@@ -27,6 +27,7 @@ export class AttachmentImpl extends AbstractAttachment {
 
   static async connect(client: ClientImpl, uri: string, options?: ConnectOptions): Promise<AttachmentImpl> {
     const attachment = new AttachmentImpl(client);
+    attachment.encoding = mapCharsetToEncoding(options?.charset);
 
     return await client.statusAction(async (status) => {
       const dpb = createDpb(options);

--- a/packages/node-firebird-driver-native/src/lib/statement.ts
+++ b/packages/node-firebird-driver-native/src/lib/statement.ts
@@ -53,12 +53,18 @@ export class StatementImpl extends AbstractStatement {
 
       if (statement.inMetadata) {
         statement.inBuffer = new Uint8Array(statement.inMetadata.getMessageLengthSync(status));
-        statement.dataWriter = createDataWriter(createDescriptors(status, statement.inMetadata), attachment.encoding);
+        statement.dataWriter = createDataWriter(
+          createDescriptors(status, statement.inMetadata),
+          attachment.charsetCodec,
+        );
       }
 
       if (statement.outMetadata) {
         statement.outBuffer = new Uint8Array(statement.outMetadata.getMessageLengthSync(status));
-        statement.dataReader = createDataReader(createDescriptors(status, statement.outMetadata), attachment.encoding);
+        statement.dataReader = createDataReader(
+          createDescriptors(status, statement.outMetadata),
+          attachment.charsetCodec,
+        );
       }
 
       return statement;

--- a/packages/node-firebird-driver-native/src/lib/statement.ts
+++ b/packages/node-firebird-driver-native/src/lib/statement.ts
@@ -53,12 +53,12 @@ export class StatementImpl extends AbstractStatement {
 
       if (statement.inMetadata) {
         statement.inBuffer = new Uint8Array(statement.inMetadata.getMessageLengthSync(status));
-        statement.dataWriter = createDataWriter(createDescriptors(status, statement.inMetadata));
+        statement.dataWriter = createDataWriter(createDescriptors(status, statement.inMetadata), attachment.encoding);
       }
 
       if (statement.outMetadata) {
         statement.outBuffer = new Uint8Array(statement.outMetadata.getMessageLengthSync(status));
-        statement.dataReader = createDataReader(createDescriptors(status, statement.outMetadata));
+        statement.dataReader = createDataReader(createDescriptors(status, statement.outMetadata), attachment.encoding);
       }
 
       return statement;

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -19,6 +19,7 @@ import {
 
 /** AbstractAttachment implementation. */
 export abstract class AbstractAttachment implements Attachment {
+  encoding: BufferEncoding = 'utf8';
   events = new Set<Events>();
   statements = new Set<AbstractStatement>();
   transactions = new Set<AbstractTransaction>();

--- a/packages/node-firebird-driver/src/lib/impl/attachment.ts
+++ b/packages/node-firebird-driver/src/lib/impl/attachment.ts
@@ -19,7 +19,6 @@ import {
 
 /** AbstractAttachment implementation. */
 export abstract class AbstractAttachment implements Attachment {
-  encoding: BufferEncoding = 'utf8';
   events = new Set<Events>();
   statements = new Set<AbstractStatement>();
   transactions = new Set<AbstractTransaction>();

--- a/packages/node-firebird-driver/src/lib/impl/fb-util.ts
+++ b/packages/node-firebird-driver/src/lib/impl/fb-util.ts
@@ -1,8 +1,5 @@
 import * as os from 'os';
 const littleEndian = os.endianness() === 'LE';
-
-import * as stringDecoder from 'string_decoder';
-
 import { AbstractAttachment } from './attachment';
 import { decodeDate, decodeTime, encodeDate, encodeTime } from './date-time';
 import { tzIdToString, tzStringToId } from './time-zones';

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -45,6 +45,9 @@ export interface ConnectOptions {
   /** User role. */
   role?: string;
 
+  /** Connection charset (lc_ctype). Defaults to 'utf8'. */
+  charset?: string;
+
   /** Set database read/write mode. */
   setDatabaseReadWriteMode?: DatabaseReadWriteMode;
 }


### PR DESCRIPTION
## Problem

Legacy Firebird databases commonly use charset `NONE` on text columns. In these databases, text is stored as raw bytes in the application's encoding (typically WIN1252) without any charset metadata on the columns.

The driver currently hardcodes `utf8` as the connection charset (`lc_ctype` in the DPB). When connecting to a database with charset `NONE` columns, Firebird does not transliterate the data: it sends the raw bytes as-is. The driver then incorrectly decodes these WIN1252 bytes as UTF-8, corrupting accented characters:

- `Tournée` → `Tourn�e`
- `Café` → `Caf�`

This affects a large number of production Firebird databases where charset `NONE` was the default.

## Solution

Add a `charset` option to `ConnectOptions` that:

1. **Sets the DPB `lc_ctype`** to the specified charset instead of hardcoded `utf8`
2. **Propagates the charset to the data reader/writer** so string encoding/decoding matches the connection charset

### Usage

```typescript
const attachment = await client.connect('host:database', {
  username: 'SYSDBA',
  password: 'masterkey',
  charset: 'WIN1252',
});
```

### How it works

- `mapCharsetToEncoding()` maps Firebird charset names to Node.js `BufferEncoding` values (`utf8` for UTF8, `latin1` for all single-byte charsets)
- `latin1` encoding in Node.js provides a 1:1 byte-to-codepoint mapping, which correctly handles any single-byte Firebird charset (WIN1252, ISO8859_1, WIN1250, etc.)
- The encoding is stored on `AbstractAttachment` and passed through to `createDataReader()` and `createDataWriter()` via `StatementImpl.prepare()`

### Changes

- `node-firebird-driver`:
  - `ConnectOptions`: add optional `charset` property
  - `createDpb()`: use `options.charset` instead of hardcoded `'utf8'`
  - `mapCharsetToEncoding()`: new helper to map Firebird charset → Node.js encoding
  - `AbstractAttachment`: add `encoding` property
  - `createDataReader()` / `createDataWriter()`: accept `encoding` parameter

- `node-firebird-driver-native`:
  - `AttachmentImpl.connect()`: set `encoding` from `mapCharsetToEncoding(options.charset)`
  - `StatementImpl.prepare()`: pass `attachment.encoding` to reader/writer

### Backward compatible

When `charset` is not specified, the behavior is identical to before (defaults to `utf8`).