### PR TITLE
Fix OCTETS charset handling for SQL_VARYING values

### DIFF
--- a/packages/node-firebird-driver/src/lib/impl/fb-util.ts
+++ b/packages/node-firebird-driver/src/lib/impl/fb-util.ts
@@ -155,6 +155,7 @@ export namespace cancelType {
 
 export namespace charSets {
   export const none = 0;
+  export const octets = 1;
   export const ascii = 2;
 }
 
@@ -376,10 +377,14 @@ export function createDataReader(descriptors: Descriptor[]): DataReader {
       switch (descriptor.type) {
         // SQL_TEXT is handled changing its descriptor to SQL_VARYING with IMetadataBuilder.
         case sqlTypes.SQL_VARYING: {
-          // TODO: octets
           const varLength = dataView.getUint16(descriptor.offset, littleEndian);
-          const encoding = descriptor.charSet === charSets.none ? attachment.charSetForNONE : 'utf8';
           const buf = Buffer.from(buffer.buffer, descriptor.offset + 2, varLength);
+
+          if (descriptor.charSet === charSets.octets) {
+            return Buffer.from(buf);
+          }
+
+          const encoding = descriptor.charSet === charSets.none ? attachment.charSetForNONE : 'utf8';
           return decodeString(buf, encoding);
         }
 
@@ -592,18 +597,20 @@ export function createDataWriter(descriptors: Descriptor[]): DataWriter {
       switch (descriptor.type) {
         // SQL_TEXT is handled changing its descriptor to SQL_VARYING with IMetadataBuilder.
         case sqlTypes.SQL_VARYING: {
-          //// TODO: octets
-          const str = value as string;
-          const encoding = descriptor.charSet === charSets.none ? attachment.charSetForNONE : 'utf8';
-          const strBuffer = encodeString(str, encoding);
+          let bytesArray: Uint8Array;
 
-          const bytesArray = Uint8Array.from(strBuffer);
+          if (descriptor.charSet === charSets.octets) {
+            bytesArray = Uint8Array.from(value as Uint8Array);
+          } else {
+            const str = value as string;
+            const encoding = descriptor.charSet === charSets.none ? attachment.charSetForNONE : 'utf8';
+            const strBuffer = encodeString(str, encoding);
+            bytesArray = Uint8Array.from(strBuffer);
+          }
 
           if (bytesArray.length > descriptor.length) {
-            throw new Error(
-              `Length in bytes of string '${str}' (${bytesArray.length}) is ` +
-                `greater than maximum expect length ${descriptor.length}.`,
-            );
+            throw new Error(`Length in bytes of value (${bytesArray.length}) is ` +
+              `greater than maximum expect length ${descriptor.length}.`);
           }
 
           dataView.setUint16(descriptor.offset, bytesArray.length, littleEndian);

--- a/packages/node-firebird-driver/src/lib/impl/fb-util.ts
+++ b/packages/node-firebird-driver/src/lib/impl/fb-util.ts
@@ -609,8 +609,10 @@ export function createDataWriter(descriptors: Descriptor[]): DataWriter {
           }
 
           if (bytesArray.length > descriptor.length) {
-            throw new Error(`Length in bytes of value (${bytesArray.length}) is ` +
-              `greater than maximum expect length ${descriptor.length}.`);
+            throw new Error(
+              `Length in bytes of value (${bytesArray.length}) is ` +
+                `greater than maximum expect length ${descriptor.length}.`,
+            );
           }
 
           dataView.setUint16(descriptor.offset, bytesArray.length, littleEndian);

--- a/packages/node-firebird-driver/src/test/fb-util.test.ts
+++ b/packages/node-firebird-driver/src/test/fb-util.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from 'vitest';
-import { createDpb, dpb } from '../lib/impl/fb-util';
+import { describe, expect, it, test } from 'vitest';
+
+import {
+  charSets,
+  createDataReader,
+  createDataWriter,
+  createDpb,
+  dpb,
+  sqlTypes,
+  type Descriptor,
+} from '../lib/impl/fb-util';
 
 describe('createDpb', () => {
   test('handles searchPath string and array options', () => {
@@ -22,5 +31,32 @@ describe('createDpb', () => {
     expect(() => createDpb({ searchPath: longSearchPathArray })).toThrowError(
       'ConnectOptions.searchPath length cannot exceed 255.',
     );
+  });
+});
+
+describe('fb-util', () => {
+  it('preserves raw bytes for SQL_VARYING fields with OCTETS charset', async () => {
+    const descriptor: Descriptor = {
+      type: sqlTypes.SQL_VARYING,
+      subType: 0,
+      charSet: charSets.octets,
+      length: 4,
+      scale: 0,
+      offset: 2,
+      nullOffset: 0,
+    };
+
+    const buffer = new Uint8Array(16);
+    const writer = createDataWriter([descriptor]);
+    const reader = createDataReader([descriptor]);
+
+    const expected = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+
+    await writer({} as any, {} as any, buffer, [expected]);
+
+    const result = await reader({ charSetForNONE: 'utf8' } as any, {} as any, buffer);
+
+    expect(Buffer.isBuffer(result[0])).toBe(true);
+    expect(result[0]).toEqual(expected);
   });
 });

--- a/packages/node-firebird-driver/src/test/tests.ts
+++ b/packages/node-firebird-driver/src/test/tests.ts
@@ -1086,6 +1086,35 @@ export function runCommonTests(client: Client) {
         }
       });
 
+      test('OCTETS charset preserves raw bytes for read/write', async () => {
+        const filename = getDriverTestDatabaseUri(testConfig, 'ResultSet-octets-charset.fdb');
+
+        const attachment = await client.createDatabase(filename);
+        const transaction = await attachment.startTransaction();
+        await attachment.execute(transaction, 'create table t1 (id integer, x varchar(4) character set octets)');
+        await transaction.commitRetaining();
+
+        await attachment.execute(
+          transaction,
+          "insert into t1 (id, x) values (1, cast(x'000102ff' as varchar(4) character set octets))",
+        );
+
+        const bytes = Buffer.from([0x00, 0x7f, 0x80, 0xff]);
+        await attachment.execute(transaction, 'insert into t1 (id, x) values (2, ?)', [bytes]);
+
+        const row1 = await attachment.executeSingleton(transaction, 'select x from t1 where id = 1');
+        const row2 = await attachment.executeSingleton(transaction, 'select x from t1 where id = 2');
+
+        expect(Buffer.isBuffer(row1[0])).toBeTruthy();
+        expect(row1[0]).toEqual(Buffer.from([0x00, 0x01, 0x02, 0xff]));
+
+        expect(Buffer.isBuffer(row2[0])).toBeTruthy();
+        expect(row2[0]).toEqual(bytes);
+
+        await transaction.commit();
+        await attachment.dropDatabase();
+      });
+
       test('#fetch() with fetchSize', async () => {
         const attachment = await client.createDatabase(
           getDriverTestDatabaseUri(testConfig, 'ResultSet-fetch-with-fetchSize.fdb'),


### PR DESCRIPTION
- Fixes OCTETS handling for SQL_VARYING values by preserving raw bytes on read and write.
- Adds a regression test to cover the round-trip behavior for OCTETS-backed values.
- Verified with:
./node_modules/.bin/vitest run packages/node-firebird-driver/src/test/fb-util.test.ts