### PR TITLE
feat(driver): add ConnectOptions.searchPath for Firebird 6 SQL schemas

### DIFF
--- a/packages/node-firebird-driver/src/lib/impl/fb-util.ts
+++ b/packages/node-firebird-driver/src/lib/impl/fb-util.ts
@@ -65,6 +65,7 @@ export namespace dpb {
   export const specific_auth_data = 84;
   export const auth_plugin_list = 85;
   export const auth_plugin_name = 86;
+  export const search_path = 105;
 }
 
 /** TPB constants. */
@@ -184,6 +185,17 @@ export function createDpb(options?: ConnectOptions | CreateDatabaseOptions): Buf
 
   if (options.role) {
     ret += `${code(dpb.sql_role_name)}${code(options.role.length)}${options.role}`;
+  }
+
+  const searchPath = Array.isArray(options.searchPath)
+    ? options.searchPath
+        .map((schema) => schema.trim())
+        .filter((schema) => schema.length > 0)
+        .join(',')
+    : options.searchPath?.trim();
+
+  if (searchPath) {
+    ret += `${code(dpb.search_path)}${code(searchPath.length)}${searchPath}`;
   }
 
   const createOptions = options as CreateDatabaseOptions;

--- a/packages/node-firebird-driver/src/lib/impl/fb-util.ts
+++ b/packages/node-firebird-driver/src/lib/impl/fb-util.ts
@@ -195,6 +195,10 @@ export function createDpb(options?: ConnectOptions | CreateDatabaseOptions): Buf
     : options.searchPath?.trim();
 
   if (searchPath) {
+    if (searchPath.length > 255) {
+      throw new Error('ConnectOptions.searchPath length cannot exceed 255.');
+    }
+
     ret += `${code(dpb.search_path)}${code(searchPath.length)}${searchPath}`;
   }
 

--- a/packages/node-firebird-driver/src/lib/index.ts
+++ b/packages/node-firebird-driver/src/lib/index.ts
@@ -49,6 +49,19 @@ export interface ConnectOptions {
   setDatabaseReadWriteMode?: DatabaseReadWriteMode;
 
   /**
+   * Firebird 6+ SQL schema search path: which schemas unqualified names resolve through, in order.
+   *
+   * Sent as the `isc_dpb_search_path` attachment parameter, so it is in effect before the session's
+   * first statement — unlike `SET SEARCH_PATH`, which is a statement of its own. Accepts a list or
+   * a comma-separated string. The server appends `SYSTEM` itself, and silently ignores the
+   * parameter when the negotiated protocol predates Firebird 6.
+   *
+   * Note there is no separate "default schema": `CURRENT_SCHEMA` is the first existing entry of
+   * this path, so putting a schema first is how a default is expressed.
+   */
+  searchPath?: string | string[];
+
+  /**
    * Node.js character set encoding used for Firebird NONE charset columns/parameters.
    * Requires iconv-lite package.
    */

--- a/packages/node-firebird-driver/src/test/fb-util.test.ts
+++ b/packages/node-firebird-driver/src/test/fb-util.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { createDpb, dpb } from '../lib/impl/fb-util';
+
+describe('createDpb', () => {
+  test('handles searchPath string and array options', () => {
+    const bufString = createDpb({ username: 'sysdba', searchPath: 'SCHEMA1,SCHEMA2' });
+    expect(bufString.includes(Buffer.from('SCHEMA1,SCHEMA2'))).toBeTruthy();
+    expect(bufString.includes(Buffer.from([dpb.search_path, 'SCHEMA1,SCHEMA2'.length]))).toBeTruthy();
+
+    const bufArray = createDpb({ username: 'sysdba', searchPath: [' SCHEMA1 ', 'SCHEMA2 ', ''] });
+    expect(bufArray.includes(Buffer.from('SCHEMA1,SCHEMA2'))).toBeTruthy();
+    expect(bufArray.includes(Buffer.from([dpb.search_path, 'SCHEMA1,SCHEMA2'.length]))).toBeTruthy();
+  });
+
+  test('throws error if searchPath length exceeds 255', () => {
+    const longSearchPath = 'a'.repeat(256);
+    expect(() => createDpb({ searchPath: longSearchPath })).toThrowError(
+      'ConnectOptions.searchPath length cannot exceed 255.',
+    );
+
+    const longSearchPathArray = ['a'.repeat(130), 'b'.repeat(130)];
+    expect(() => createDpb({ searchPath: longSearchPathArray })).toThrowError(
+      'ConnectOptions.searchPath length cannot exceed 255.',
+    );
+  });
+});


### PR DESCRIPTION
Implements #172.

Adds `ConnectOptions.searchPath`, sent as the `isc_dpb_search_path` attachment parameter (tag
`105`), so an application can choose which schemas unqualified names resolve through *before* the
session's first statement runs.

### The change

25 lines across two files, following the existing `role` handling:

- `ConnectOptions.searchPath?: string | string[]`
- `dpb.search_path = 105`
- `createDpb()` emits it next to `sql_role_name`

Entries are trimmed and empty ones dropped, so a stray comma cannot produce an empty schema name.

There is deliberately **no separate "default schema" option**: Firebird has no such DPB tag, because
`CURRENT_SCHEMA` is simply the first existing entry of the search path. Putting a schema first is
how a default is expressed, which the doc comment says.

No version check is needed before attaching — the server ignores the parameter when the negotiated
protocol predates Firebird 6.

### Verification

Against a live **Firebird 6.0.0** server through `node-firebird-driver-native`, with a probe table
that exists in **one** schema only. That detail matters: a table present in both schemas would
resolve either way and prove nothing.

| `searchPath` | `RDB$GET_CONTEXT('SYSTEM','SEARCH_PATH')` | `SELECT ID FROM ONLY_IN_SALES` |
| --- | --- | --- |
| *(unset)* | `"PUBLIC", "SYSTEM"` | `-204 Table unknown` |
| `['SALES']` | `"SALES", "SYSTEM"` | `ID=42` |
| `'SALES,PUBLIC'` | `"SALES", "PUBLIC", "SYSTEM"` | `ID=42` |

`tsc -p packages/node-firebird-driver` reports no errors in `src/lib`. I could not run the
monorepo's full `yarn`/`lerna` build in my environment, so the CI build and the existing test suite
have not been run against this branch — worth a look before merging. `prettier --config .prettierrc`
reports both files unchanged.

### Why

[Firebird Studio for VS Code](https://github.com/mariuz/vscode-firebird-studio) supports both this
driver and the pure-JS `node-firebird` behind one interface, and lets a user set a default schema
per connection. `node-firebird` 2.14.2 added the same parameter, so the pure-JS path applies the
schema at attach time while the native path has to fall back to `SET SEARCH_PATH` as the session's
first statement — the two drivers behave subtly differently for the same user setting. This closes
that gap.
